### PR TITLE
Thread safety for RouterMetrics maps

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -133,5 +133,6 @@ func (fs *FloodSubRouter) Flush()                                               
 func (fs *FloodSubRouter) WithHeartbeatProxy(heartbeatProxy HeartbeatProxyFn)          {}
 func (fs *FloodSubRouter) GetGossipSubParams() *GossipSubParams                        { return nil }
 func (fs *FloodSubRouter) GetRouterMetrics() *RouterMetrics                            { return nil }
+func (fs *FloodSubRouter) FullMessagesInc()                                            {}
 func (fs *FloodSubRouter) PublishToPeers(data []byte, topic string, peerIDs []peer.ID) {}
 func (gs *FloodSubRouter) EnqueueGossip(p peer.ID, ihave *pb.ControlIHave)             {}

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"sort"
+	"sync"
 	"time"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -247,6 +248,14 @@ type RouterMetrics struct {
 	SentControlMessages uint64
 	SentMessagesTotal   uint64
 
+	// mu guards HandledControlMessagesByPid and SentControlMessagesToPeer maps.
+	// These maps are mutated by the internal processLoop goroutine (via HandleRPC,
+	// RemovePeer) and by external callers invoking the exported SendRPC (via doSendRPC)
+	// from separate goroutines. GetRouterMetrics() also reads and deep-copies the maps
+	// from another goroutine. Go maps are not safe for concurrent access and will cause
+	// a fatal panic, so the mutex is acquired for writes in the mutation methods and
+	// for reads in GetRouterMetrics().
+	mu                          sync.RWMutex
 	HandledControlMessagesByPid map[peer.ID]uint64
 	SentControlMessagesToPeer   map[peer.ID]uint64
 
@@ -257,16 +266,28 @@ type RouterMetrics struct {
 }
 
 func (m *RouterMetrics) SentControlMessagesByPidInc(pid peer.ID) {
+	m.mu.Lock()
 	m.SentControlMessagesToPeer[pid]++
+	m.mu.Unlock()
 }
 func (m *RouterMetrics) SentControlMessagesByPidRemove(pid peer.ID) {
+	m.mu.Lock()
 	delete(m.SentControlMessagesToPeer, pid)
+	m.mu.Unlock()
 }
 func (m *RouterMetrics) HandledControlMessagesByPidInc(pid peer.ID) {
+	m.mu.Lock()
 	m.HandledControlMessagesByPid[pid]++
+	m.mu.Unlock()
 }
 func (m *RouterMetrics) HandledControlMessagesByPidRemove(pid peer.ID) {
+	m.mu.Lock()
 	delete(m.HandledControlMessagesByPid, pid)
+	m.mu.Unlock()
+}
+
+func (m *RouterMetrics) FullMessagesInc() {
+	m.FullMessages++
 }
 
 // NewGossipSub returns a new PubSub object using the default GossipSubRouter as the router.
@@ -1416,13 +1437,13 @@ func (gs *GossipSubRouter) doDropRPC(rpc *RPC, p peer.ID, reason string) {
 
 func (gs *GossipSubRouter) doSendRPC(rpc *RPC, p peer.ID, q *rpcQueue, urgent bool) {
 	if rpc.GetControl() != nil {
-		gs.GetRouterMetrics().SentControlMessagesByPidInc(p)
-		gs.GetRouterMetrics().SentControlMessages++
+		gs.RouterMetrics.SentControlMessagesByPidInc(p)
+		gs.RouterMetrics.SentControlMessages++
 	}
 	if rpc.GetPublish() != nil {
-		gs.GetRouterMetrics().SentPublishMessages++
+		gs.RouterMetrics.SentPublishMessages++
 	}
-	gs.GetRouterMetrics().SentMessagesTotal++
+	gs.RouterMetrics.SentMessagesTotal++
 
 	var err error
 	if urgent {
@@ -2316,9 +2337,35 @@ func (gs *GossipSubRouter) WithHeartbeatProxy(heartbeatProxy HeartbeatProxyFn) {
 	gs.heartbeatProxy = heartbeatProxy
 }
 
-// Export router metrics
+// Export router metrics. Returns a deep copy safe for concurrent use.
 func (gs *GossipSubRouter) GetRouterMetrics() *RouterMetrics {
-	return gs.RouterMetrics
+	gs.RouterMetrics.mu.RLock()
+	defer gs.RouterMetrics.mu.RUnlock()
+
+	snapshot := &RouterMetrics{
+		FullMessages:        gs.RouterMetrics.FullMessages,
+		ControlMessages:     gs.RouterMetrics.ControlMessages,
+		SentPublishMessages: gs.RouterMetrics.SentPublishMessages,
+		SentControlMessages: gs.RouterMetrics.SentControlMessages,
+		SentMessagesTotal:   gs.RouterMetrics.SentMessagesTotal,
+		IHAVE:               gs.RouterMetrics.IHAVE,
+		IWANT:               gs.RouterMetrics.IWANT,
+		GRAFT:               gs.RouterMetrics.GRAFT,
+		PRUNE:               gs.RouterMetrics.PRUNE,
+	}
+	snapshot.SentControlMessagesToPeer = make(map[peer.ID]uint64, len(gs.RouterMetrics.SentControlMessagesToPeer))
+	for k, v := range gs.RouterMetrics.SentControlMessagesToPeer {
+		snapshot.SentControlMessagesToPeer[k] = v
+	}
+	snapshot.HandledControlMessagesByPid = make(map[peer.ID]uint64, len(gs.RouterMetrics.HandledControlMessagesByPid))
+	for k, v := range gs.RouterMetrics.HandledControlMessagesByPid {
+		snapshot.HandledControlMessagesByPid[k] = v
+	}
+	return snapshot
+}
+
+func (gs *GossipSubRouter) FullMessagesInc() {
+	gs.RouterMetrics.FullMessagesInc()
 }
 
 // Export router metrics

--- a/pubsub.go
+++ b/pubsub.go
@@ -236,6 +236,7 @@ type PubSubRouter interface {
 
 	// Export metrics
 	GetRouterMetrics() *RouterMetrics
+	FullMessagesInc()
 }
 
 type AcceptStatus int
@@ -1117,8 +1118,7 @@ func (p *PubSub) handleIncomingRPC(rpc *RPC) {
 	case AcceptAll:
 
 		// Router Metrics - Full Message
-		routerMetrics := p.rt.GetRouterMetrics()
-		routerMetrics.FullMessages += 1
+		p.rt.FullMessagesInc()
 
 		var toPush []*Message
 		for _, pmsg := range rpc.GetPublish() {

--- a/randomsub.go
+++ b/randomsub.go
@@ -193,5 +193,6 @@ func (rs *RandomSubRouter) Flush()                                              
 func (rs *RandomSubRouter) WithHeartbeatProxy(heartbeatProxy HeartbeatProxyFn)          {}
 func (rs *RandomSubRouter) GetGossipSubParams() *GossipSubParams                        { return nil }
 func (rs *RandomSubRouter) GetRouterMetrics() *RouterMetrics                            { return nil }
+func (rs *RandomSubRouter) FullMessagesInc()                                            {}
 func (rs *RandomSubRouter) PublishToPeers(data []byte, topic string, peerIDs []peer.ID) {}
 func (gs *RandomSubRouter) EnqueueGossip(p peer.ID, ihave *pb.ControlIHave)             {}


### PR DESCRIPTION
## Problem

  RouterMetrics contains two maps (SentControlMessagesToPeer, HandledControlMessagesByPid) that are accessed
  concurrently from multiple goroutines without synchronization:

  1. processLoop goroutine — writes to maps via HandleRPC, RemovePeer
  2. External callers (e.g. attack-simulator spammers) — write to maps via exported SendRPC → doSendRPC
  3. Metrics collection goroutine — reads maps via GetRouterMetrics()

  Go maps are not safe for concurrent access and concurrent read/write causes a fatal runtime panic.

  Additionally, `GetRouterMetrics()` returned a pointer to the live RouterMetrics struct, meaning callers shared the
  same underlying map data with the router — any concurrent mutation by the router while the caller iterates the maps
  would also panic.

## Solution

  - Add `sync.RWMutex` to `RouterMetrics` guarding the two map fields
  - Wrap map mutation methods (`SentControlMessagesByPidInc`, `SentControlMessagesByPidRemove`,
  `HandledControlMessagesByPidInc`, `HandledControlMessagesByPidRemove`) with write locks
  - `GetRouterMetrics()` now returns a deep copy — acquires a read lock, copies all scalar fields and clones both maps,
  so callers get an independent snapshot with no shared state
  - `doSendRPC` accesses `gs.RouterMetrics` directly instead of going through `GetRouterMetrics()`, which now returns a copy and would silently discard writes
  - Add `FullMessagesInc()` to `PubSubRouter` interface — replaces the pattern of `GetRouterMetrics().FullMessages += 1` in `pubsub.go`, which would no longer work since `GetRouterMetrics()` returns a copy